### PR TITLE
Fixed stringifyStyle() to replace all capital letters

### DIFF
--- a/src/toString.js
+++ b/src/toString.js
@@ -7,9 +7,10 @@ function renderToString(vnode) {
   var attrs = ""
   for (var i in attrNames) {
     var currentAttrName = attrNames[i]
-    var content = currentAttrName == "style"
-      ? stringifyStyle(vnode.data[currentAttrName])
-      : vnode.data[currentAttrName]
+    var content =
+      currentAttrName == "style"
+        ? stringifyStyle(vnode.data[currentAttrName])
+        : vnode.data[currentAttrName]
 
     attrs += " " + currentAttrName + '="' + content + '"'
   }
@@ -32,7 +33,10 @@ function stringifyStyle(style) {
   for (var i in properties) {
     var curProp = properties[i]
     inlineStyle +=
-      curProp.replace(/[A-Z]/, "-$&").toLowerCase() + ":" + style[curProp] + ";"
+      curProp.replace(/[A-Z]/g, "-$&").toLowerCase() +
+      ":" +
+      style[curProp] +
+      ";"
   }
 
   return inlineStyle

--- a/test/toString.test.js
+++ b/test/toString.test.js
@@ -44,6 +44,10 @@ test("style", () => {
     {
       vnode: createVNode({ data: { style: { backgroundColor: "papayawhip" } } }),
       html: `<div style="background-color:papayawhip;"></div>`
+    },
+    {
+      vnode: createVNode({ data: { style: { backgroundColor: "papayawhip", borderTopLeftRadius: "10px" } } }),
+      html: `<div style="background-color:papayawhip;border-top-left-radius:10px;"></div>`
     }
   ])
 })


### PR DESCRIPTION
This PR fixes `stringifyStyle()` function. Old version only changed the first capital letter. So for example this code:
```javascript
const style = {
    backgroundColor: 'rgb(0, 0, 0)',
    borderTopRightRadius: '4px',
    borderTopLeftRadius: '4px'
};
```
would become this:
```css
    background-color: rgb(0, 0, 0);
    border-toprightradius: 4px;
    border-topleftradius: 4px;
```
which is not a valid css and this PR fixes it.