### PR TITLE
renderToString() Upgrades

### DIFF
--- a/src/toString.js
+++ b/src/toString.js
@@ -1,3 +1,21 @@
+var voidElements = {
+  area: true,
+  base: true,
+  br: true,
+  col: true,
+  embed: true,
+  hr: true,
+  img: true,
+  input: true,
+  keygen: true,
+  link: true,
+  meta: true,
+  param: true,
+  source: true,
+  track: true,
+  wbr: true
+}
+
 function renderToString(vnode) {
   var tag = vnode.tag
   var children = vnode.children
@@ -13,6 +31,11 @@ function renderToString(vnode) {
         : vnode.data[currentAttrName]
 
     attrs += " " + currentAttrName + '="' + content + '"'
+  }
+
+  // Void tags cannot have children, so return early
+  if (voidElements[tag]) {
+    return "<" + tag + attrs + ">"
   }
 
   // Get the child nodes of the current vnode

--- a/src/toString.js
+++ b/src/toString.js
@@ -5,7 +5,7 @@ function renderToString(vnode) {
   var attrNames = Object.keys(vnode.data)
 
   var attrs = ""
-  for (var i in attrNames) {
+  for (var i = 0; i < attrNames.length; i++) {
     var currentAttrName = attrNames[i]
     var content =
       currentAttrName == "style"
@@ -17,7 +17,7 @@ function renderToString(vnode) {
 
   // Get the child nodes of the current vnode
   var childHTML = ""
-  for (var i in children) {
+  for (var i = 0; i < children.length; i++) {
     var child = children[i]
     if (child.tag) childHTML += renderToString(child)
     if (typeof child == "string") childHTML += child
@@ -30,7 +30,7 @@ function renderToString(vnode) {
 function stringifyStyle(style) {
   var properties = Object.keys(style)
   var inlineStyle = ""
-  for (var i in properties) {
+  for (var i = 0; i < properties.length; i++) {
     var curProp = properties[i]
     inlineStyle +=
       curProp.replace(/[A-Z]/g, "-$&").toLowerCase() +

--- a/src/toString.js
+++ b/src/toString.js
@@ -25,12 +25,14 @@ function renderToString(vnode) {
   var attrs = ""
   for (var i = 0; i < attrNames.length; i++) {
     var currentAttrName = attrNames[i]
-    var content =
-      currentAttrName == "style"
-        ? stringifyStyle(vnode.data[currentAttrName])
-        : vnode.data[currentAttrName]
+    if (typeof vnode.data[currentAttrName] !== "function") {
+      var content =
+        currentAttrName == "style"
+          ? stringifyStyle(vnode.data[currentAttrName])
+          : vnode.data[currentAttrName]
 
-    attrs += " " + currentAttrName + '="' + content + '"'
+      attrs += " " + currentAttrName + '="' + content + '"'
+    }
   }
 
   // Void tags cannot have children, so return early

--- a/test/toString.test.js
+++ b/test/toString.test.js
@@ -88,3 +88,30 @@ test("vnode children", () => {
     }
   ])
 })
+
+test("void tags", () => {
+  RenderTest([
+    {
+      vnode: createVNode({
+        tag: "input",
+        data: { type: "text" }
+      }),
+      html: `<input type="text">`
+    },
+    {
+      vnode: createVNode({
+        tag: "img",
+        data: { src: "http://example.com/img.jpg" }
+      }),
+      html: `<img src="http://example.com/img.jpg">`
+    },
+    {
+      vnode: createVNode({
+        tag: "input",
+        data: { type: "text" },
+        children: [createVNode()]
+      }),
+      html: `<input type="text">`
+    },
+  ])
+})

--- a/test/toString.test.js
+++ b/test/toString.test.js
@@ -35,6 +35,21 @@ test("attributes", () => {
   ])
 })
 
+test("handler functions", () => {
+  function handler() { return "y" }
+
+  RenderTest([
+    {
+      vnode: createVNode({ data: { id: "a", oncreate: () => "x" } }),
+      html: `<div id="a"></div>`
+    },
+    {
+      vnode: createVNode({ data: { id: "a", onclick: handler } }),
+      html: `<div id="a"></div>`
+    }
+  ])
+})
+
 test("style", () => {
   RenderTest([
     {


### PR DESCRIPTION
This PR contains a few changes to this `renderToString()` function.

1. Changed `for (var i in array)` loops to normal `for (var i=0; i < array.length; i++)` loops for performance.
    [See this JSPerf](https://jsperf.com/rendertostring-opt).  On my computers w/ Chrome, this was 2x faster.
2. Added support for HTML void tags.  Per spec, they are not allowed to have children or closing tags.
3. Don't render attributes if they are functions.

What else would people like to see done?   We could add string escaping to prevent script injections, but is that overstepping the boundary of this package?

@andyrj Will this get used at all in your SSR implementation?